### PR TITLE
Add GitHub Actions workflows for multi-platform build and release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,57 @@
+# Professional GitHub Actions workflow for Go multi-platform builds (production-ready)
+#
+# - Builds and uploads binaries for every commit/PR on main branch
+# - Cross-compiles for major OS/arch targets
+# - Uses Go build cache for faster builds
+# - Artifacts retained for 14 days
+# - Fail-fast and matrix optimizations
+
+name: Build (Multi-Platform)
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    name: Build Binaries
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        goos: [linux, windows, darwin]
+        goarch: [amd64, arm64]
+        exclude:
+          - goos: darwin
+            goarch: arm64 # Enable if you want darwin/arm64 (Apple Silicon)
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: true
+
+      - name: Cache Go build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Build
+        run: |
+          mkdir -p dist
+          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -trimpath -ldflags="-s -w" -o dist/melodix-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/melodix
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: melodix-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: dist/melodix-${{ matrix.goos }}-${{ matrix.goarch }}
+          retention-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+# Professional release workflow for Go multi-platform binaries
+#
+# On new tag, builds binaries for major OS/arch, attaches to GitHub Release named after the tag.
+
+name: Release
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    name: Release Binaries
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux, windows, darwin]
+        goarch: [amd64, arm64]
+        exclude:
+          - goos: darwin
+            goarch: arm64 # Only build darwin/arm64 if needed, comment out to enable
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - name: Build
+        run: |
+          mkdir -p dist
+          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -trimpath -ldflags="-s -w" -o dist/melodix-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/melodix
+      - name: Upload Release Asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/melodix-${{ matrix.goos }}-${{ matrix.goarch }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces two new GitHub Actions workflows to streamline the build and release processes for the Go project. The workflows are designed to support cross-platform builds, optimize performance with caching, and automate artifact handling for both commits and tagged releases.

### New GitHub Actions Workflows:

#### Build Workflow:
* Added a multi-platform build workflow (`.github/workflows/build.yml`) that triggers on commits and pull requests to the `main` branch. It cross-compiles binaries for `linux`, `windows`, and `darwin` operating systems with `amd64` and `arm64` architectures, excluding `darwin/arm64` by default.
* Implements Go build caching to speed up the build process and retains build artifacts for 14 days.

#### Release Workflow:
* Added a release workflow (`.github/workflows/release.yml`) that triggers on new tags matching the pattern `v*`. It builds binaries for the same platforms and attaches them to a GitHub Release corresponding to the tag.
* Uses the `softprops/action-gh-release` action to upload release assets, leveraging the `GITHUB_TOKEN` secret for authentication.

For example for release v2025-01-21, it will be as simple as create a tag with name v2025-01-21 and it will auto-release