### PR TITLE
fix(discord): keep quiet gateway sessions alive

### DIFF
--- a/internal/discord/session_health.go
+++ b/internal/discord/session_health.go
@@ -84,12 +84,21 @@ func (b *Bot) startSessionHealthWatchers(
 		func(meta watchdog.WSSilenceMeta) {
 			b.log.Warn().
 				Dur("since_last_ws", meta.SinceLastWS).
+				Dur("since_last_heartbeat_ack", meta.SinceLastHeartbeatAck).
 				Dur("timeout", meta.Timeout).
 				Dur("heartbeat_latency", meta.HeartbeatLatency).
 				Msg("gateway_silent")
 			notifyUnhealthy()
 		},
-		watchdog.WSSilenceOptions{SettleDelay: 15 * time.Second, Tick: 10 * time.Second},
+		watchdog.WSSilenceOptions{
+			SettleDelay: 15 * time.Second,
+			Tick:        10 * time.Second,
+			LastHeartbeatAck: func() time.Time {
+				dg.RLock()
+				defer dg.RUnlock()
+				return dg.LastHeartbeatAck
+			},
+		},
 	).Run(sessionCtx)
 
 	go func() {

--- a/internal/discord/watchdog/ws_silence.go
+++ b/internal/discord/watchdog/ws_silence.go
@@ -6,18 +6,20 @@ import (
 )
 
 type WSSilenceMeta struct {
-	SinceLastWS      time.Duration
-	HeartbeatLatency time.Duration
-	Timeout          time.Duration
+	SinceLastWS           time.Duration
+	SinceLastHeartbeatAck time.Duration
+	HeartbeatLatency      time.Duration
+	Timeout               time.Duration
 }
 
 // WSSilence restarts a session when the gateway receive loop appears silent.
 //
-// Behavior is intentionally simple and mirrors the old inline logic:
+// Behavior is intentionally simple:
 // - waits settleDelay before starting checks
 // - ticks every tick interval
 // - does nothing until tracker reports ready
-// - triggers unhealthy when time since last WS exceeds timeout
+// - triggers unhealthy when both dispatch traffic and heartbeat ACKs are stale
+// - preserves dispatch-only behavior when no heartbeat ACK source is configured
 type WSSilence struct {
 	tracker     *Tracker
 	timeout     time.Duration
@@ -25,12 +27,14 @@ type WSSilence struct {
 	tick        time.Duration
 
 	heartbeatLatency func() time.Duration
+	lastHeartbeatAck func() time.Time
 	onUnhealthy      func(meta WSSilenceMeta)
 }
 
 type WSSilenceOptions struct {
-	SettleDelay time.Duration
-	Tick        time.Duration
+	SettleDelay      time.Duration
+	Tick             time.Duration
+	LastHeartbeatAck func() time.Time
 }
 
 func NewWSSilence(tracker *Tracker, timeout time.Duration, heartbeatLatency func() time.Duration, onUnhealthy func(meta WSSilenceMeta), opts WSSilenceOptions) *WSSilence {
@@ -46,8 +50,47 @@ func NewWSSilence(tracker *Tracker, timeout time.Duration, heartbeatLatency func
 		settleDelay:      opts.SettleDelay,
 		tick:             opts.Tick,
 		heartbeatLatency: heartbeatLatency,
+		lastHeartbeatAck: opts.LastHeartbeatAck,
 		onUnhealthy:      onUnhealthy,
 	}
+}
+
+func (w *WSSilence) unhealthyMeta(now time.Time) (WSSilenceMeta, bool) {
+	if w == nil || w.tracker == nil || w.timeout <= 0 || !w.tracker.IsReady() {
+		return WSSilenceMeta{}, false
+	}
+
+	sinceWS := w.tracker.SinceLastWS(now)
+	if sinceWS <= w.timeout {
+		return WSSilenceMeta{}, false
+	}
+
+	var sinceHeartbeatAck time.Duration
+	if w.lastHeartbeatAck != nil {
+		lastAck := w.lastHeartbeatAck()
+		if !lastAck.IsZero() {
+			if now.Before(lastAck) {
+				sinceHeartbeatAck = 0
+			} else {
+				sinceHeartbeatAck = now.Sub(lastAck)
+			}
+			if sinceHeartbeatAck <= w.timeout {
+				return WSSilenceMeta{}, false
+			}
+		}
+	}
+
+	var latency time.Duration
+	if w.heartbeatLatency != nil {
+		latency = w.heartbeatLatency()
+	}
+
+	return WSSilenceMeta{
+		SinceLastWS:           sinceWS,
+		SinceLastHeartbeatAck: sinceHeartbeatAck,
+		HeartbeatLatency:      latency,
+		Timeout:               w.timeout,
+	}, true
 }
 
 func (w *WSSilence) Run(ctx context.Context) {
@@ -69,20 +112,8 @@ func (w *WSSilence) Run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case now := <-ticker.C:
-			if !w.tracker.IsReady() {
-				continue
-			}
-			since := w.tracker.SinceLastWS(now)
-			if since > w.timeout {
-				lat := time.Duration(0)
-				if w.heartbeatLatency != nil {
-					lat = w.heartbeatLatency()
-				}
-				w.onUnhealthy(WSSilenceMeta{
-					SinceLastWS:      since,
-					HeartbeatLatency: lat,
-					Timeout:          w.timeout,
-				})
+			if meta, unhealthy := w.unhealthyMeta(now); unhealthy {
+				w.onUnhealthy(meta)
 				return
 			}
 		}

--- a/internal/discord/watchdog/ws_silence_test.go
+++ b/internal/discord/watchdog/ws_silence_test.go
@@ -1,0 +1,91 @@
+package watchdog
+
+import (
+	"testing"
+	"time"
+)
+
+func readyTrackerAt(lastWS time.Time) *Tracker {
+	tracker := NewTracker()
+	tracker.lastWSNano.Store(lastWS.UnixNano())
+	tracker.readyNano.Store(lastWS.UnixNano())
+	return tracker
+}
+
+func TestWSSilenceKeepsQuietSessionWithFreshHeartbeatHealthy(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	watcher := NewWSSilence(
+		readyTrackerAt(now.Add(-3*time.Minute)),
+		2*time.Minute,
+		func() time.Duration { return 100 * time.Millisecond },
+		nil,
+		WSSilenceOptions{LastHeartbeatAck: func() time.Time { return now.Add(-10 * time.Second) }},
+	)
+
+	if meta, unhealthy := watcher.unhealthyMeta(now); unhealthy {
+		t.Fatalf("quiet session with a fresh heartbeat was unhealthy: %+v", meta)
+	}
+}
+
+func TestWSSilenceTriggersWhenDispatchAndHeartbeatAreStale(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	watcher := NewWSSilence(
+		readyTrackerAt(now.Add(-3*time.Minute)),
+		2*time.Minute,
+		func() time.Duration { return 100 * time.Millisecond },
+		nil,
+		WSSilenceOptions{LastHeartbeatAck: func() time.Time { return now.Add(-4 * time.Minute) }},
+	)
+
+	meta, unhealthy := watcher.unhealthyMeta(now)
+	if !unhealthy {
+		t.Fatal("session with stale dispatch and heartbeat was healthy")
+	}
+	if meta.SinceLastWS != 3*time.Minute {
+		t.Fatalf("SinceLastWS = %s, want 3m", meta.SinceLastWS)
+	}
+	if meta.SinceLastHeartbeatAck != 4*time.Minute {
+		t.Fatalf("SinceLastHeartbeatAck = %s, want 4m", meta.SinceLastHeartbeatAck)
+	}
+}
+
+func TestWSSilencePreservesLegacyBehaviorWithoutHeartbeatSource(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	watcher := NewWSSilence(
+		readyTrackerAt(now.Add(-3*time.Minute)),
+		2*time.Minute,
+		nil,
+		nil,
+		WSSilenceOptions{},
+	)
+
+	if _, unhealthy := watcher.unhealthyMeta(now); !unhealthy {
+		t.Fatal("stale dispatch without a heartbeat source was healthy")
+	}
+}
+
+func TestWSSilencePreservesLegacyBehaviorBeforeFirstHeartbeatAck(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	watcher := NewWSSilence(
+		readyTrackerAt(now.Add(-3*time.Minute)),
+		2*time.Minute,
+		nil,
+		nil,
+		WSSilenceOptions{LastHeartbeatAck: func() time.Time { return time.Time{} }},
+	)
+
+	if _, unhealthy := watcher.unhealthyMeta(now); !unhealthy {
+		t.Fatal("stale dispatch before the first heartbeat ACK was healthy")
+	}
+}
+
+func TestWSSilenceWaitsUntilReady(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	tracker := NewTracker()
+	tracker.lastWSNano.Store(now.Add(-3 * time.Minute).UnixNano())
+	watcher := NewWSSilence(tracker, 2*time.Minute, nil, nil, WSSilenceOptions{})
+
+	if _, unhealthy := watcher.unhealthyMeta(now); unhealthy {
+		t.Fatal("session was unhealthy before ready")
+	}
+}


### PR DESCRIPTION
Fixes #7.

### What changed

The WS silence watchdog now checks DiscordGo's most recent heartbeat ACK before restarting a session:

- dispatch silence with a fresh heartbeat ACK is treated as healthy;
- stale dispatches and stale heartbeat ACKs still trigger recovery;
- deployments without an ACK source, and startup before the first ACK, preserve the previous dispatch-only behavior;
- `gateway_silent` logs now include `since_last_heartbeat_ack`.

This matches DiscordGo's behavior: Op 11 is consumed internally and updates `Session.LastHeartbeatAck`; it is not delivered to the generic event handler that updates the dispatch tracker.

### Tests

- Added focused watchdog tests for fresh/stale ACKs, legacy behavior, first-ACK startup, and readiness.
- `go test ./...` passes with Go 1.26 on Alpine.
- Deployed the patched image to the reproducing environment and observed it past the previous 2-minute failure threshold with zero `gateway_silent` events and zero session restarts.