### PR TITLE
fix(docker): enable yt-dlp YouTube challenges

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,13 +33,20 @@ RUN BUILD_DATE=$(date -u +"%Y-%m-%dT%H-%M-%SZ") && \
 FROM alpine:latest
 
 # Runtime dependencies
+# yt-dlp needs an external JS runtime and its EJS component for full YouTube
+# support. The embedded web client avoids GVS formats that require a PO token.
 RUN apk add --no-cache \
         ffmpeg \
+        nodejs \
         python3 \
         py3-pip \
         libstdc++ \
         alsa-lib \
-    && pip3 install --no-cache-dir --break-system-packages yt-dlp \
+    && pip3 install --no-cache-dir --break-system-packages 'yt-dlp[default]' \
+    && printf '%s\n' \
+        '--js-runtimes node' \
+        '--extractor-args youtube:player_client=web_embedded' \
+        > /etc/yt-dlp.conf \
     && rm -rf /var/cache/apk/*
 
 WORKDIR /usr/project


### PR DESCRIPTION
### Summary

YouTube playback in the Docker image can fail across every fallback with `LOGIN_REQUIRED`, `HTTP 403`, and yt-dlp exit status 183.

Recent yt-dlp releases need an external JavaScript runtime and the EJS challenge solver for full YouTube support. The current image installs neither.

### Changes

- install Alpine's Node.js runtime (currently Node 24, above yt-dlp's Node 22 minimum);
- install `yt-dlp[default]`, which includes `yt-dlp-ejs`;
- enable Node globally through `/etc/yt-dlp.conf`;
- use the `web_embedded` player client, which resolves working formats without cookies or a GVS PO token where the default `android_vr` client returns 403.

The configuration is global, so both `ytdlp-link` and `ytdlp-pipe` use it without application-code changes.

### Verification

- Docker image builds successfully on Alpine.
- Node 24.18.1 and yt-dlp-ejs 0.8.0 are detected in the resulting image.
- Three public videos that previously failed across all parsers download successfully with the image configuration.
- A resolved audio URL decodes successfully through FFmpeg.
- The image was deployed to the reproducing environment; the bot reconnected to Discord with zero container restarts or watchdog errors.